### PR TITLE
알림톡에 대체메세지 옵션 추가 (버튼 url 숏링크)

### DIFF
--- a/app/services/bizmsg_service.rb
+++ b/app/services/bizmsg_service.rb
@@ -10,8 +10,8 @@ class BizmsgService
     ).call
   end
 
-  def initialize(template_id:, phone:, message_type:, reserve_dt:, template_params:)
-    @template_service = KakaoTemplateService.new(template_id, message_type, phone, reserve_dt)
+  def initialize(template_id:, phone:, message_type:, reserve_dt:, template_params:, alt_sms_btn_indexes: [])
+    @template_service = KakaoTemplateService.new(template_id, message_type, phone, reserve_dt, alt_sms_btn_indexes)
     @template_params = template_params
     @template_id = template_id
   end

--- a/app/services/kakao_notification_service.rb
+++ b/app/services/kakao_notification_service.rb
@@ -1,18 +1,19 @@
 class KakaoNotificationService
   include NotificationRequestHelper
 
-  def self.call(template_id:, phone:, message_type: "AT", reserve_dt: nil, template_params:)
+  def self.call(template_id:, phone:, message_type: "AT", reserve_dt: nil, template_params:, alt_sms_btn_indexes: [])
     new(
       template_id: template_id,
       phone: phone,
       message_type: message_type,
       reserve_dt: reserve_dt,
-      template_params: template_params
+      template_params: template_params,
+      alt_sms_btn_indexes: alt_sms_btn_indexes
     ).call
   end
 
-  def initialize(template_id:, phone:, message_type:, reserve_dt:, template_params:)
-    @template_service = KakaoTemplateService.new(template_id, message_type, phone, reserve_dt)
+  def initialize(template_id:, phone:, message_type:, reserve_dt:, template_params:, alt_sms_btn_indexes:)
+    @template_service = KakaoTemplateService.new(template_id, message_type, phone, reserve_dt, alt_sms_btn_indexes)
     @template_params = template_params
     @template_id = template_id
   end

--- a/app/services/notification/factory/job_support_request_agreement.rb
+++ b/app/services/notification/factory/job_support_request_agreement.rb
@@ -27,7 +27,9 @@ class Notification::Factory::JobSupportRequestAgreement < Notification::Factory:
         @message_template_id,
         @user.phone_number,
         params,
-        @user.public_id, 'AI'
+        @user.public_id, 'AI',
+        nil,
+        [0]
       ))
 
   end

--- a/app/services/notification/factory/send_medium/bizm_post_pay_message.rb
+++ b/app/services/notification/factory/send_medium/bizm_post_pay_message.rb
@@ -1,11 +1,11 @@
 class Notification::Factory::SendMedium::BizmPostPayMessage < Notification::Factory::SendMedium::Abstract
   include NotificationRequestHelper
-  def initialize(message_template_id, phone, params, target_public_id, message_type = "AT", reserved_dt = nil)
+  def initialize(message_template_id, phone, params, target_public_id, message_type = "AT", reserved_dt = nil, alt_sms_btn_indexes = [])
     @message_template_id = message_template_id
     params[:target_public_id] = target_public_id
     @params = params
     @target_public_id = target_public_id
-    @bizm_template_service = KakaoTemplateService.new(message_template_id, message_type, phone, reserved_dt)
+    @bizm_template_service = KakaoTemplateService.new(message_template_id, message_type, phone, reserved_dt, alt_sms_btn_indexes)
   end
 
   def send_request

--- a/app/services/notification/factory/send_medium/bizm_pre_pay_message.rb
+++ b/app/services/notification/factory/send_medium/bizm_pre_pay_message.rb
@@ -1,10 +1,10 @@
 class Notification::Factory::SendMedium::BizmPrePayMessage < Notification::Factory::SendMedium::Abstract
   include NotificationRequestHelper
-  def initialize(message_template_id, message_type, phone, params, target_public_id)
+  def initialize(message_template_id, message_type, phone, params, target_public_id, alt_sms_btn_indexes = [])
     @message_template_id = message_template_id
     @params = params
     @target_public_id = target_public_id
-    @bizm_template_service = KakaoTemplateService.new(message_template_id, message_type, phone, nil)
+    @bizm_template_service = KakaoTemplateService.new(message_template_id, message_type, phone, nil, alt_sms_btn_indexes)
   end
 
   def send_request

--- a/app/services/notification/factory/send_news_paper.rb
+++ b/app/services/notification/factory/send_news_paper.rb
@@ -37,7 +37,7 @@ class Notification::Factory::SendNewsPaper < Notification::Factory::Notification
           )
         )
       else
-        @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, message.phone_number, template_params, template_params["target_public_id"], "AI"))
+        @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, message.phone_number, template_params, template_params["target_public_id"], "AI", nil, [0]))
       end
     end
   end


### PR DESCRIPTION
![IMG_2533](https://github.com/bosalpim/worknet-job-posting/assets/77750865/fc8dea9b-f9a6-4ae4-99e4-bffdc5ab5e03)

대체 메세지(카카오톡 전송 오류시 sms 메세지 내용)에 버튼 url의 숏링크를 넣을 수 있는 옵션을 추가했습니다.
메세지 class(BizmPostPayMessage, BizmPrePayMessage, NotificationRequestHelper)에 마지막 prop으로 number array를 추가할 수 있습니다. 해당 index에 있는 버튼을 숏링크로 변환해서 본문 아래에 추가합니다.

예시 39f9201e22a28bf9c5ec4a3e9223e2f69babd1db df7cb1d1b33dbcb4ab470238c6075fb78cbee1b0