### PR TITLE
동네광고 지원 이벤트 로깅 수정

### DIFF
--- a/app/services/notification/factory/target_job_posting_ad_apply.rb
+++ b/app/services/notification/factory/target_job_posting_ad_apply.rb
@@ -58,7 +58,7 @@ class Notification::Factory::TargetJobPostingAdApply < Notification::Factory::No
       application_type: application_type,
       user_name: @user.name.present? ? (@user.name + "**") : "**",
       center_name: @business.name,
-      target_public_id: @job_posting.public_id,
+      target_public_id: @client.public_id,
       title: @job_posting.title,
       address: get_dong_name_by_address(@job_posting.address),
       count: {


### PR DESCRIPTION
target_public_id가 클라이언트 아이디여야 하는데 잘못되어 수정합니다.