### PR TITLE
FIX: 따로 설정을 하지 않을 경우, 테스트 폰으로 알림이 발송되지 않도록 설정

### DIFF
--- a/app/services/kakao_template_service.rb
+++ b/app/services/kakao_template_service.rb
@@ -192,6 +192,8 @@ class KakaoTemplateService
                phone
              elsif Main::Application::PHONE_NUMBER_WHITELIST.is_a?(Array) && Main::Application::PHONE_NUMBER_WHITELIST.include?(phone)
                phone
+             else
+               raise "스테이징 서버에 등록되지 않은 핸드폰 번호입니다. worknet-job-posting 프로젝트에 WhiteList에 추가해주세요"
              end
   end
 

--- a/app/services/kakao_template_service.rb
+++ b/app/services/kakao_template_service.rb
@@ -192,8 +192,6 @@ class KakaoTemplateService
                phone
              elsif Main::Application::PHONE_NUMBER_WHITELIST.is_a?(Array) && Main::Application::PHONE_NUMBER_WHITELIST.include?(phone)
                phone
-             else
-               Main::Application::TEST_PHONE_NUMBER
              end
   end
 


### PR DESCRIPTION
모든 알림에 대해서, 테스트 사용자의 번호가 아닐경우 default로 테스트폰에 알림톡이 전송돼, 비용 낭비되는 것 제거