### PR TITLE
CHORE : 앱 배포 완료에 따른 API 변경 배포

### DIFF
--- a/app/jobs/start_send_newspaper_job.rb
+++ b/app/jobs/start_send_newspaper_job.rb
@@ -37,4 +37,8 @@ class StartSendNewspaperJob < ApplicationJob
                               })
     )
   end
+
+  def news_paper_test_call
+    CreateNewsPaperActivelyCommonMessageService.test_call
+  end
 end

--- a/app/services/fcm/fcm_service.rb
+++ b/app/services/fcm/fcm_service.rb
@@ -48,6 +48,9 @@ class Fcm::FcmService
         notification: {
           title: message[:title],
           body: message[:body]
+        },
+        data: {
+          deeplink: message[:link]
         }
       }
     }

--- a/app/services/notification/factory/send_medium/app_push.rb
+++ b/app/services/notification/factory/send_medium/app_push.rb
@@ -13,14 +13,13 @@ class Notification::Factory::SendMedium::AppPush < Notification::Factory::SendMe
   # FCM
   def send_request
     begin
-      response = request_app_push({ to: @to, collapse_key: @collapse_key, notification: @notification })
-      success = response["success"]
-      if success == 1
+      response = Fcm::FcmService.instance.send_message(@to, @notification)
+      if response.dig(:success)
         amplitude_log unless @logging_properties.nil?
         return { status: 'success', response: response, target_public_id: @target_public_id }
       else
         begin
-          if response["results"].first["error"] == 'NotRegistered'
+          if response['errorCode'] == 'UNREGISTERED' || response['errorCode'] == 'INVALID_ARGUMENT'
             UserPushToken.find_by(token: @to).destroy rescue nil
             ClientPushToken.find_by(token: @to).destroy rescue nil
           end
@@ -28,7 +27,7 @@ class Notification::Factory::SendMedium::AppPush < Notification::Factory::SendMe
           Jets.logger.error e.full_message
         end
 
-        return { status: 'fail', response: response.to_s, target_public_id: @target_public_id }
+        return { status: 'fail', response: response['errorCode'], target_public_id: @target_public_id }
       end
     rescue Net::ReadTimeout
       return { status: 'fail', response: "NET::TIMEOUT", target_public_id: @target_public_id }


### PR DESCRIPTION
딥링크 대응한 앱의 배포가 완료되어,
신규 앱푸쉬 서비스 Fcm::FcmService로 변경 진행합니다.

아래 함수로 테스트할 예정입니다.
def news_paper_test_call
  CreateNewsPaperActivelyCommonMessageService.test_call
end