### PR TITLE
FEATURE: 파라미터로 radius를 설정해서 동네광고를 보낼 수 있도록 설정

### DIFF
--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -160,6 +160,7 @@ class NotificationController < ApplicationController
           message_template_id: MessageTemplates[MessageNames::TARGET_USER_JOB_POSTING],
           params: {
             job_posting_id: params[:job_posting_id],
+            radius: params[:radius]
           }
         }
         Jets.env.development? ?

--- a/app/services/notification/factory/target_user_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_job_posting_service.rb
@@ -14,7 +14,11 @@ class Notification::Factory::TargetUserJobPostingService < Notification::Factory
     @deeplink_scheme = Main::Application::DEEP_LINK_SCHEME
     prefer_work_type = @job_posting.work_type == 'hospital' ? 'etc' : @job_posting.work_type
     begin
-      @radius = params[:radius] ? Integer(params[:radius]) : (@job_posting.is_facility? ? 5000 : 3000)
+      @radius = if params[:radius]
+                  Integer(params[:radius])
+                else
+                  @job_posting.is_facility? ? 5000 : 3000
+                end
     rescue ArgumentError, TypeError
       @radius = @job_posting.is_facility? ? 5000 : 3000
     end

--- a/app/services/notification/factory/target_user_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_job_posting_service.rb
@@ -13,10 +13,15 @@ class Notification::Factory::TargetUserJobPostingService < Notification::Factory
     @base_url = "#{Main::Application::CAREPARTNER_URL}/jobs/#{@job_posting.public_id}"
     @deeplink_scheme = Main::Application::DEEP_LINK_SCHEME
     prefer_work_type = @job_posting.work_type == 'hospital' ? 'etc' : @job_posting.work_type
+    begin
+      @radius = params[:radius] ? Integer(params[:radius]) : (@job_posting.is_facility? ? 5000 : 3000)
+    rescue ArgumentError, TypeError
+      @radius = @job_posting.is_facility? ? 5000 : 3000
+    end
     @list = User
               .receive_job_notifications
               .within_radius(
-                @job_posting.is_facility? ? 5000 : 3000,
+                @radius,
                 @job_posting.lat,
                 @job_posting.lng,
               ).where.not(phone_number: nil)


### PR DESCRIPTION
공고 등록시 무료로 1km 이내까지 알림 보낼 수 있게 하기 위해서, 동네광고 전송 api에 radius 파라미터 추가.
radius 파라미터가 없거나, radius를 integer로 변환할 수 없을 경우에는 기존 로직(3km or 5km) 기준으로 전송