### PR TITLE
HOTFIX: 동네광고에 connection pool 원인 되는 sms 제거

### DIFF
--- a/app/services/notification/factory/target_user_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_job_posting_service.rb
@@ -77,9 +77,7 @@ class Notification::Factory::TargetUserJobPostingService < Notification::Factory
         job_posting_type: @job_posting.work_type,
       },
       user.public_id,
-      "AI",
-      nil,
-      [0]
+      "AI"
     )
   end
 

--- a/app/services/notification/factory/target_user_resident_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_resident_job_posting_service.rb
@@ -63,9 +63,7 @@ class Notification::Factory::TargetUserResidentJobPostingService < Notification:
         job_posting_type: @job_posting.work_type,
       },
       user.public_id,
-      "AI",
-      nil,
-      [0]
+      "AI"
     )
   end
   def generate_message_content


### PR DESCRIPTION
sms 생성 때 short url를 만들어주는 부분에서, 조건문에 신문만 반영이 되고 있는 상황에서 동네광고에도 sms을 추가하여 문제 발생.
일단 동네광고 sms 생성 제거 뒤, short url 만드는 조건문에 동네광고를 추가하는 것으로 조치 예정