### PR TITLE
FIX : 입주요양 공고등록 시, 동네광고 전환 시 15km 2번 중복발송 / 동네광고 메세지 효율 전환 확인 데이터 생성 에러 처리 변경

### DIFF
--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -70,6 +70,7 @@ class NotificationController < ApplicationController
           message_template_id: TARGET_USER_RESIDENT_POSTING,
           params: {
             job_posting_id: params[:job_posting_id],
+            radius: params[:radius]
           }
         }
         Jets.env.development? ?

--- a/app/services/notification/factory/dispatched_notifications/service.rb
+++ b/app/services/notification/factory/dispatched_notifications/service.rb
@@ -23,13 +23,13 @@ class Notification::Factory::DispatchedNotifications::Service
         next if result[:status] != 'success'
         target_public_id = result[:target_public_id]
         receiver_id = find_receiver_id(target_public_id)
-        DispatchedNotification.create({
+        DispatchedNotification.upsert({
                                         message_template_name: @template_name,
                                         notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
                                         notification_relate_instance_id: @relate_instance_id,
                                         receiver_type: @receiver_type,
                                         receiver_id: receiver_id
-                                      })
+                                      }, unique_by: ["message_template_name", "notification_relate_instance_id", "notification_relate_instance_types_id", "receiver_type", "receiver_id"])
       rescue => e
         Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
       end

--- a/app/services/notification/factory/dispatched_notifications/service.rb
+++ b/app/services/notification/factory/dispatched_notifications/service.rb
@@ -12,27 +12,27 @@ class Notification::Factory::DispatchedNotifications::Service
   end
 
   def set_dispatced_notifications(results)
-    begin
       @send_results = results
       save_dispatced_notifications
-    rescue => e
-      Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
-    end
   end
 
   private
   def save_dispatced_notifications
     @send_results.each do |result|
-      next if result[:status] != 'success'
-      target_public_id = result[:target_public_id]
-      receiver_id = find_receiver_id(target_public_id)
-      DispatchedNotification.create!({
-                                       message_template_name: @template_name,
-                                       notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
-                                       notification_relate_instance_id: @relate_instance_id,
-                                       receiver_type: @receiver_type,
-                                       receiver_id: receiver_id
-                                     })
+      begin
+        next if result[:status] != 'success'
+        target_public_id = result[:target_public_id]
+        receiver_id = find_receiver_id(target_public_id)
+        DispatchedNotification.upsert({
+                                        message_template_name: @template_name,
+                                        notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
+                                        notification_relate_instance_id: @relate_instance_id,
+                                        receiver_type: @receiver_type,
+                                        receiver_id: receiver_id
+                                      }, unique_by: ["message_template_name", "notification_relate_instance_id", "notification_relate_instance_types_id", "receiver_type", "receiver_id"])
+      rescue => e
+        Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
+      end
     end
   end
 

--- a/app/services/notification/factory/dispatched_notifications/service.rb
+++ b/app/services/notification/factory/dispatched_notifications/service.rb
@@ -23,13 +23,13 @@ class Notification::Factory::DispatchedNotifications::Service
         next if result[:status] != 'success'
         target_public_id = result[:target_public_id]
         receiver_id = find_receiver_id(target_public_id)
-        DispatchedNotification.upsert({
+        DispatchedNotification.create({
                                         message_template_name: @template_name,
                                         notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
                                         notification_relate_instance_id: @relate_instance_id,
                                         receiver_type: @receiver_type,
                                         receiver_id: receiver_id
-                                      }, unique_by: ["message_template_name", "notification_relate_instance_id", "notification_relate_instance_types_id", "receiver_type", "receiver_id"])
+                                      })
       rescue => e
         Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
       end

--- a/app/services/notification/factory/target_user_resident_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_resident_job_posting_service.rb
@@ -11,11 +11,12 @@ class Notification::Factory::TargetUserResidentJobPostingService < Notification:
     @job_posting = JobPosting.find(params[:job_posting_id])
     @base_url = "#{Main::Application::CAREPARTNER_URL}jobs/#{@job_posting.public_id}"
     @deeplink_scheme = Main::Application::DEEP_LINK_SCHEME
+    radius = params[:radius].nil? ? 15000 : params[:radius]
     @list = User
               .receive_job_notifications
               .selected_resident
               .within_radius(
-                15000,
+                radius,
                 @job_posting.lat,
                 @job_posting.lng,
                 ).where.not(phone_number: nil)


### PR DESCRIPTION
https://bosalpim.slack.com/archives/C03RLT4TL4C/p1716014200459289?thread_ts=1716008026.420329&cid=C03RLT4TL4C

<발송된 메세지 개수와 동네광고 발송된 메세지 개수가 다른 이슈 트래킹 내용>

동네광고 메세지 발송 과정안에는 2가지 단계가 있습니다.
1. 동네광고 메세지를 보내는 과정
2. 동네광고 전환 효율을 체크용 데이터 생성 과정

1번 과정에서 1000개의 입주요양 일자리 발송을 완료하고,
2번 과정을 진행하던 중 전환 확인 데이터가 생성되지 않은 **동네광고 메세지를 받은 요양보호사 선생님이 먼저 접속**하시면, bbas dispatched-notifications을 통해 동네광고 메세지 데이터가 먼저 생성됩니다. 

이때, create 하던 과정에서 unique 룰에 위배되어 에러가 발생하고, 에러 처리 단위가 배열의 element가 아닌 배열 전체로 되어있습니다.
만약, 여기서 300개까지 데이터를 처리했다면, 남은 700개의 동네광고 메세지 동네광고 전환 효율을 체크용 데이터 생성은 실행되지 않게되고, 실질적으로 1000개의 메세지가 나갔지만 기관 유저가 보는 대시보드 상에서는 300개가 나간 것으로 보이게 됩니다.

----------------------------------------------------

<코드 수정사항>

배열의 element 단위로 실패처리를 해야하는데, 배열 전체를 단위로 begin/rescue를 수행하게 되어
element 하나에서 문제가 생기면 뒤에 남은 모든 element가 버려지는 현상을 제거합니다.