### PR TITLE
REFACTOR: 알림톡 @job_posting_id_for_notification_results를 @job_posting으로 공통화

### DIFF
--- a/app/services/notification/factory/job_ads_first_message.rb
+++ b/app/services/notification/factory/job_ads_first_message.rb
@@ -15,7 +15,6 @@ class Notification::Factory::JobAdsFirstMessage < Notification::Factory::Notific
     @list = Notification::Factory::SearchTarget::JobAdsFirstTargetService.call(job_posting)
     @dispatched_notifications_service = DispatchedNotificationService.call(@message_template_id, "job_posting", @job_posting.id, "yobosa")
     @notification_create_service = NotificationCreateService.call(@message_template_id, "급구 일자리 지금 확인해보세요!", @job_posting.title, @end_point, "yobosa")
-    @job_posting_id_for_notification_results = job_posting.id
     create_message
   end
 

--- a/app/services/notification/factory/job_ads_second_message.rb
+++ b/app/services/notification/factory/job_ads_second_message.rb
@@ -17,7 +17,6 @@ class Notification::Factory::JobAdsSecondMessage < Notification::Factory::Notifi
     @retarget_users = target.dig(:retarget_users)
     @dispatched_notifications_service = DispatchedNotificationService.call(@message_template_id, "job_posting", @job_posting.id, "yobosa")
     @notification_create_service = NotificationCreateService.call(@message_template_id, "조건에 딱 맞는 일자리 확인했나요?", @job_posting.title, @end_point, "yobosa")
-    @job_posting_id_for_notification_results = job_posting.id
     create_message
   end
 

--- a/app/services/notification/factory/job_ads_third_message.rb
+++ b/app/services/notification/factory/job_ads_third_message.rb
@@ -17,7 +17,6 @@ class Notification::Factory::JobAdsThirdMessage < Notification::Factory::Notific
     @retarget_users = target.dig(:retarget_users)
     @dispatched_notifications_service = DispatchedNotificationService.call(@message_template_id, "job_posting", @job_posting.id, "yobosa")
     @notification_create_service = NotificationCreateService.call(@message_template_id, "조건에 딱 맞는 일자리가 도착했어요.", @job_posting.title, @end_point, "yobosa")
-    @job_posting_id_for_notification_results = job_posting.id
     create_message
   end
 

--- a/app/services/notification/factory/job_posting_target_message_service.rb
+++ b/app/services/notification/factory/job_posting_target_message_service.rb
@@ -16,7 +16,6 @@ class Notification::Factory::JobPostingTargetMessageService < Notification::Fact
     job_posting = JobPosting.find(job_posting_id)
     @job_posting = job_posting
     @end_point = "/jobs/#{@job_posting.public_id}"
-    @job_posting_id_for_notification_results = job_posting.id
     @list = JobPostingTargetUserService.call(@job_posting.lat, @job_posting.lng)
     @dispatched_notifications_service = DispatchedNotificationService.call(@message_template_id, "target_message", @job_posting.id, "yobosa")
     @fail_alert_message_payload = {

--- a/app/services/notification/factory/job_posting_target_message_v3_service.rb
+++ b/app/services/notification/factory/job_posting_target_message_v3_service.rb
@@ -14,7 +14,6 @@ class Notification::Factory::JobPostingTargetMessageV3Service < Notification::Fa
 
     @job_posting = JobPosting.find(params[:job_posting_id])
     @end_point = "/jobs/#{@job_posting.public_id}"
-    @job_posting_id_for_notification_results = job_posting.id
     @distance = @job_posting.is_facility? ? 5_000 : 3_000
     @list = User.receive_job_notifications.within_radius(@distance, @job_posting.lat, @job_posting.lng)
     @dispatched_notifications_service = DispatchedNotificationService.call(@message_template_id, "target_message", @job_posting.id, "yobosa")

--- a/app/services/notification/factory/new_job_notification.rb
+++ b/app/services/notification/factory/new_job_notification.rb
@@ -14,7 +14,6 @@ class Notification::Factory::NewJobNotification < Notification::Factory::Notific
     job_posting = JobPosting.find(job_posting_id)
     @job_posting = job_posting
     @end_point = "/jobs/#{@job_posting.public_id}"
-    @job_posting_id_for_notification_results = job_posting.id
     @list = NewJobPostingUsersService.call(job_posting)
     @notification_create_service = NotificationCreateService.call(@message_template_id, "신규 일자리 알림", @job_posting.title, @end_point, "yobosa")
     create_message

--- a/app/services/notification/factory/notification_factory_class.rb
+++ b/app/services/notification/factory/notification_factory_class.rb
@@ -30,9 +30,10 @@ class Notification::Factory::NotificationFactoryClass
     @notification_create_service = nil
     @message_template_id = message_template_id
 
-    # 어떤 공고를 통해 발생한 것인지, 파악하기 위한 Id를 받는 변수
-    # 각 서브클래스에서 주입
-    @job_posting_id_for_notification_results = nil
+    # 어떤 공고를 통해 발생한 것인지, 파악하기 위한 공고 객체를 받는 변수
+    # 각 서브클래스에서 공고를 가져올 때 주입
+    @job_posting = nil
+
     @fail_alert_message_payload = nil
 
     message_template = MessageTemplate.find_by(name: message_template_id)
@@ -68,11 +69,11 @@ class Notification::Factory::NotificationFactoryClass
   def save_result
     Jets.logger.info "전체 발송 대상자 : #{@list.nil? ? 0 : @list.count} 명 발송처리 완료"
     # app push 결과 처리
-    save_results_app_push(@app_push_result, @message_template_id, @job_posting_id_for_notification_results)
+    save_results_app_push(@app_push_result, @message_template_id, @job_posting ? @job_posting.id : nil)
     # post_pay 결과 처리
-    save_results_bizm_post_pay(@bizm_post_pay_result, @message_template_id, @job_posting_id_for_notification_results)
+    save_results_bizm_post_pay(@bizm_post_pay_result, @message_template_id, @job_posting ? @job_posting.id : nil)
     # pre_pay 결과 처리
-    save_results_bizm_pre_pay(@bizm_pre_pay_result, @message_template_id, @job_posting_id_for_notification_results)
+    save_results_bizm_pre_pay(@bizm_pre_pay_result, @message_template_id, @job_posting ? @job_posting.id : nil)
   end
 
   private


### PR DESCRIPTION
@job_posting_id_for_notification_results을 클래스에서 넣어줘야만 notification_results에 job_posting.id를 넣을 수 있던 것을 리팩토링
서브 클래스에서 @job_posting으로 job_postings table를 주입하기만 해도 id가 들어가지도록 수정