### PR TITLE
FIX : 입주요양 공고등록 시, 동네광고 전환 시 15km 2번 중복발송 / 동네광고 메세지 효율 전환 확인 데이터 생성 …

### DIFF
--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -70,6 +70,7 @@ class NotificationController < ApplicationController
           message_template_id: TARGET_USER_RESIDENT_POSTING,
           params: {
             job_posting_id: params[:job_posting_id],
+            radius: params[:radius]
           }
         }
         Jets.env.development? ?

--- a/app/services/notification/factory/dispatched_notifications/service.rb
+++ b/app/services/notification/factory/dispatched_notifications/service.rb
@@ -12,27 +12,27 @@ class Notification::Factory::DispatchedNotifications::Service
   end
 
   def set_dispatced_notifications(results)
-    begin
       @send_results = results
       save_dispatced_notifications
-    rescue => e
-      Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
-    end
   end
 
   private
   def save_dispatced_notifications
     @send_results.each do |result|
-      next if result[:status] != 'success'
-      target_public_id = result[:target_public_id]
-      receiver_id = find_receiver_id(target_public_id)
-      DispatchedNotification.create!({
-                                       message_template_name: @template_name,
-                                       notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
-                                       notification_relate_instance_id: @relate_instance_id,
-                                       receiver_type: @receiver_type,
-                                       receiver_id: receiver_id
-                                     })
+      begin
+        next if result[:status] != 'success'
+        target_public_id = result[:target_public_id]
+        receiver_id = find_receiver_id(target_public_id)
+        DispatchedNotification.upsert({
+                                        message_template_name: @template_name,
+                                        notification_relate_instance_types_id: NotificationRelateInstanceType.find_by(type_name: @relate_instance_type).id,
+                                        notification_relate_instance_id: @relate_instance_id,
+                                        receiver_type: @receiver_type,
+                                        receiver_id: receiver_id
+                                      }, unique_by: ["message_template_name", "notification_relate_instance_id", "notification_relate_instance_types_id", "receiver_type", "receiver_id"])
+      rescue => e
+        Jets.logger.info "SET DISPATCHED ERROR : #{e.message}, template: #{@template_name}, instance_type: #{@relate_instance_type}, instance: #{@relate_instance_id}"
+      end
     end
   end
 

--- a/app/services/notification/factory/target_user_resident_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_resident_job_posting_service.rb
@@ -11,11 +11,12 @@ class Notification::Factory::TargetUserResidentJobPostingService < Notification:
     @job_posting = JobPosting.find(params[:job_posting_id])
     @base_url = "#{Main::Application::CAREPARTNER_URL}jobs/#{@job_posting.public_id}"
     @deeplink_scheme = Main::Application::DEEP_LINK_SCHEME
+    radius = params[:radius].nil? ? 15000 : params[:radius]
     @list = User
               .receive_job_notifications
               .selected_resident
               .within_radius(
-                15000,
+                radius,
                 @job_posting.lat,
                 @job_posting.lng,
                 ).where.not(phone_number: nil)


### PR DESCRIPTION
…에러 처리 변경 (#567)

* FIX

https://bosalpim.slack.com/archives/C03RLT4TL4C/p1716014200459289?thread_ts=1716008026.420329&cid=C03RLT4TL4C

* Update service.rb

* Revert "Update service.rb"

This reverts commit fdb27feabdd0dae4b4bb2d41037139a87928373f.