### PR TITLE
FEATURE: 60일 이내 미접속자 신문과 동네광고 발송 중지

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
 
   scope :receive_marketing, -> { where.not(marketing_agree: nil) }
   scope :receive_notifications, -> { where(notification_enabled: true) }
-  scope :receive_job_notifications, -> { where(job_notification_enabled: true).where(has_certification: true).active }
+  scope :receive_job_notifications, -> { where(job_notification_enabled: true).where(has_certification: true).active.where('last_used_at >= ? OR last_sign_in_at >= ?', 60.days.ago, 60.days.ago) }
   scope :receive_proposal_notifications, -> { where(proposal_notification_enabled: true).where(has_certification: true).active }
   scope :within_last_3_days, -> { where('last_used_at >= ?', 3.days.ago) }
   scope :within_last_7_days, -> { where('last_used_at >= ?', 7.days.ago) }


### PR DESCRIPTION
신문과 동네광고에서 사용하고 있는, 일자리 알림 필터 receive_job_notifications에 60일이내 접속 기록이 없는 경우 필터하는 쿼리 추가