### PR TITLE
v1.17.3 동네광고 카톡 발송 실패시 문자에 버튼 url 추가 (#612)

### DIFF
--- a/app/services/kakao_template_service.rb
+++ b/app/services/kakao_template_service.rb
@@ -37,7 +37,10 @@ class KakaoTemplateService
           sms_message += "\n\n"
           sms_message += btn[:name] + "↓"
           sms_message += "\n"
-          sms_message += @template_id === MessageTemplateName::NEWSPAPER_V2 ? btn[:url_mobile] : ShortUrl.build(btn[:url_mobile]).url
+          sms_message += (@template_id === MessageTemplateName::NEWSPAPER_V2 ||
+                          @template_id === MessageTemplates::TEMPLATES[MessageNames::TARGET_USER_JOB_POSTING]) ?
+                           btn[:url_mobile] :
+                           ShortUrl.build(btn[:url_mobile]).url
         end
       end
     end

--- a/app/services/notification/factory/target_user_job_posting_service.rb
+++ b/app/services/notification/factory/target_user_job_posting_service.rb
@@ -82,7 +82,9 @@ class Notification::Factory::TargetUserJobPostingService < Notification::Factory
         is_free: @is_free
       },
       user.public_id,
-      "AI"
+      "AI",
+      nil,
+      [0]
     )
   end
 


### PR DESCRIPTION
* FEATURE: 동네광고 카톡 실패시 문자에 링크 추가

* FEATURE: 동네광고에 대해서 short url을 사용하지 않도록 추가