### PR TITLE
FIX : 금요일에 추가로 발송되는 전환 유도 CRM만  나가도록 수정

### DIFF
--- a/app/jobs/draft_conversion_induce_msg_job.rb
+++ b/app/jobs/draft_conversion_induce_msg_job.rb
@@ -1,22 +1,22 @@
 class DraftConversionInduceMsgJob < ApplicationJob
   include AlimtalkMessage
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
   def first_day_except_address
     DraftConversionMessageService.call(MessageTemplates[MessageNames::ONE_DAY_CAREPARTNER_DRAFT_CRM])
   end
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
   def first_day_only_address
     DraftConversionMessageService.call(MessageTemplates[MessageNames::ONE_DAY_CAREPARTNER_ADDRESS_LEAK_CRM])
   end
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
   def second_day_except_address
     DraftConversionMessageService.call(MessageTemplates[MessageNames::TWO_DAY_CAREPARTNER_DRAFT_CRM])
   end
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
   def check_certification
     DraftConversionMessageService.call(MessageTemplateName::CERTIFICATION_UPDATE)
   end

--- a/app/jobs/notification_service_job.rb
+++ b/app/jobs/notification_service_job.rb
@@ -11,13 +11,13 @@ class NotificationServiceJob < ApplicationJob
     process({ message_template_id: MessageTemplateName::CALL_SAVED_JOB_POSTING_V2 })
   end
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
 
   def cbt_draft_until_3day
     process({ message_template_id: MessageTemplates[MessageNames::CBT_DRAFT_CRM] })
   end
 
-  cron "0 7 ? * * *"
+  cron "0 7 ? * MON-THU,SAT-SUN *"
 
   def notify_draft_new_user
     process({ message_template_id: MessageTemplates[MessageNames::ONE_DAY_CAREPARTNER_CERTFICATION_LEAK_CRM] })


### PR DESCRIPTION
금요일날 발송되는 2개(파랑)가 나머지 6개(빨강)의 대상자도 동일하게 포함하고 메세지 맥락도 맞기에 6개는 금요일에 발송하지 않습니다.
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/fe7321b8-a800-42b2-94c2-5d23c4bc41a9">
