### PR TITLE
FIX: 서버 날짜와 달라 발생하는 오류 수정 & 월요일 신문인 경우, 금요일까지 공고가 있는지 확인

### DIFF
--- a/app/services/newspaper/prepare_allday_service.rb
+++ b/app/services/newspaper/prepare_allday_service.rb
@@ -40,8 +40,8 @@ class Newspaper::PrepareAlldayService
   private
 
   def fetch_users
-    yesterday_start = DateTime.now.yesterday.beginning_of_day
-    yesterday_end = DateTime.now.yesterday.end_of_day
+    yesterday_start = DateTime.now.beginning_of_day
+    yesterday_end = DateTime.now.end_of_day
 
     User
       .receive_job_notifications

--- a/app/services/newspaper/prepare_service.rb
+++ b/app/services/newspaper/prepare_service.rb
@@ -40,8 +40,13 @@ class Newspaper::PrepareService
   private
 
   def fetch_users
-    yesterday_start = DateTime.now.beginning_of_day
-    yesterday_end = DateTime.now.end_of_day
+    today = DateTime.now
+    yesterday_start = if today.sunday?
+                        today.ago(2.days).beginning_of_day
+                      else
+                        today.beginning_of_day
+                      end
+    yesterday_end = today.end_of_day
 
     base_query = User
                    .receive_job_notifications

--- a/app/services/newspaper/prepare_service.rb
+++ b/app/services/newspaper/prepare_service.rb
@@ -40,8 +40,8 @@ class Newspaper::PrepareService
   private
 
   def fetch_users
-    yesterday_start = DateTime.now.yesterday.beginning_of_day
-    yesterday_end = DateTime.now.yesterday.end_of_day
+    yesterday_start = DateTime.now.beginning_of_day
+    yesterday_end = DateTime.now.end_of_day
 
     base_query = User
                    .receive_job_notifications


### PR DESCRIPTION
1. 서버 시간 기준으로, 전날이 전전날이기에, 실제 의도한 날짜와 맞도록 수정
2. 월요일 신문인 경우, 전날 기준이면 공고가 없기에, 금요일까지로 범위 확장
