### PR TITLE
FEATURE: 자동으로 일자리 종료시킬 때, 앰플리튜드 이벤트 로깅하도록 반영

### DIFF
--- a/app/services/job_posting/close_expired_job_postings_service.rb
+++ b/app/services/job_posting/close_expired_job_postings_service.rb
@@ -22,15 +22,6 @@ class JobPosting::CloseExpiredJobPostingsService
     target_job_posting = job_postings.where(business_id: paid_business_id_list)
     Jets.logger.info "종료대상 중 과금대상 유저의 공고 정보 : #{target_job_posting.pluck(:public_id)}"
 
-    # 종료된 공고 번개채용 전환 유도 알림톡 발송
-    if target_job_posting.count > 0
-      notification = Notification::FactoryService.create(MessageTemplateName::NOTIFY_FREE_JOB_POSTING_CLOSE,  { job_postings: target_job_posting })
-      # 발송 (ps. 메세지 성공/실패에 따른 이벤트로깅은 재발송등 사후 처리의 편의성을 위해 Amplitude 로깅이 함께 수행됩니다.)
-      notification.notify
-      # 발송결과 DB 저장 (사후 처리 대상 구분되도록 DB 내역을 생성해야합니다.)
-      notification.save_result
-    end
-
     client_events = job_postings.map do |job_posting|
       {
         user_id: job_posting.client.public_id,

--- a/app/services/job_posting/close_expired_job_postings_service.rb
+++ b/app/services/job_posting/close_expired_job_postings_service.rb
@@ -31,10 +31,15 @@ class JobPosting::CloseExpiredJobPostingsService
       notification.save_result
     end
 
-    job_postings.each do |job_posting|
-      AmplitudeService.instance.log_array([user_id: job_posting.client.public_id, event_type: "[Action] Close Job Posting",
-                                           event_properties: { by_auto: "true" } ])
+    client_events = job_postings.map do |job_posting|
+      {
+        user_id: job_posting.client.public_id,
+        event_type: "[Action] Close Job Posting",
+        event_properties: { by_auto: "true" }
+      }
     end
+
+    AmplitudeService.instance.log_array(client_events)
 
     job_postings.update_all(status: 'closed')
   end


### PR DESCRIPTION
1. 일자리 종료 조건으로 유료(동네광고) 공고도 함께 자동 종료가 되도록 수정했습니다.
2. 자동 종료 이후, close job posting 이벤트가 로깅되도록 수정했습니다.