### PR TITLE
v1.18.5 FIX: 자동종료 이벤트에서 채용 종료 로깅 분리 (#653)

### DIFF
--- a/app/services/job_posting/close_expired_job_postings_service.rb
+++ b/app/services/job_posting/close_expired_job_postings_service.rb
@@ -25,8 +25,8 @@ class JobPosting::CloseExpiredJobPostingsService
     client_events = job_postings.map do |job_posting|
       {
         user_id: job_posting.client.public_id,
-        event_type: "[Action] Close Job Posting",
-        event_properties: { by_auto: "true" }
+        event_type: "[Action] Close Job Posting By Auto",
+        event_properties: { jobPostingId: job_posting.public_id }
       }
     end
 


### PR DESCRIPTION
기존 [Action] Close Job Posting으로 배포했던 것을 Close Job Posting By Auto로 변경