### PR TITLE
FIX: 공고 자동종료 리마인드 새벽 발송 수정

### DIFF
--- a/app/services/notification/factory/notify_close_free_job_posting.rb
+++ b/app/services/notification/factory/notify_close_free_job_posting.rb
@@ -54,7 +54,6 @@ class Notification::Factory::NotifyCloseFreeJobPosting < Notification::Factory::
       target_public_id: client.public_id
     }
 
-    reserved_dt = DateTime.now.strftime("%Y%m%d") + "100000"
-    @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, client.phone_number, params, client.public_id, 'AI', reserved_dt))
+    @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, client.phone_number, params, client.public_id, 'AI'))
   end
 end


### PR DESCRIPTION
오전 10시로 지정을 했는데도, job이 돌아가는 오전4시에 발송(바로 발송)되는 버그 존재
아예 default로 오후 10시 이후에는 오전 8시 발송을 해주고 있기에, nil 값이 전달되도록 수정