### PR TITLE
FEAT : 워크넷 타켓 지역 입주/시설 공고 로직 변경

### DIFF
--- a/app/services/notification/factory/target_job_business_free_trials_service.rb
+++ b/app/services/notification/factory/target_job_business_free_trials_service.rb
@@ -56,6 +56,13 @@ class Notification::Factory::TargetJobBusinessFreeTrialsService < Notification::
           type: 'section',
           text: {
             type: 'plain_text',
+            text: "공고 타입 : #{@job_posting.work_type}"
+          }
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'plain_text',
             text: "#{@list.count} 명 발송"
           }
         }

--- a/app/services/notification/factory/target_job_business_free_trials_service.rb
+++ b/app/services/notification/factory/target_job_business_free_trials_service.rb
@@ -10,16 +10,28 @@ class Notification::Factory::TargetJobBusinessFreeTrialsService < Notification::
     @base_url = "#{Main::Application::CAREPARTNER_URL}jobs/#{@job_posting.public_id}"
     @deeplink_scheme = Main::Application::DEEP_LINK_SCHEME
     radius = params[:radius].nil? ? 3000 : params[:radius]
-    @list = User
-              .receive_job_notifications
-              .where("preferred_work_types ?| array[:work_types]", work_types: [@job_posting.work_type])
-              .where.not(phone_number: nil)
-              .within_radius(
-                radius,
-                @job_posting.lat,
-                @job_posting.lng
-              ).limit(200) + User.where(phone_number: ['01094659404', '01029465752']) # 하민, 준혁은 계속 받도록 처리
+    @list = fetch_users(radius)
     create_message
+  end
+
+  def fetch_users(radius)
+    # 사용자 지정 work_type에 따라 다른 쿼리 조건을 설정
+    if ['facility', 'resident'].include?(@job_posting.work_type)
+      # facility 또는 resident일 때는 workable_hours_per_day를 기준으로 필터링
+      base_query = User
+                     .receive_job_notifications
+                     .where(workable_hours_per_day: 8..)
+    else
+      # 다른 work_type일 때는 preferred_work_types를 기준으로 필터링
+      base_query = User
+                     .receive_job_notifications
+                     .where("preferred_work_types ?| array[:work_types]", work_types: [@job_posting.work_type])
+    end
+
+    base_query
+      .where.not(phone_number: nil)
+      .within_radius(radius, @job_posting.lat, @job_posting.lng)
+      .limit(200) + User.where(phone_number: ['01094659404', '01029465752'])
   end
 
   def save_result

--- a/app/services/notification/factory/target_job_business_free_trials_service.rb
+++ b/app/services/notification/factory/target_job_business_free_trials_service.rb
@@ -21,17 +21,17 @@ class Notification::Factory::TargetJobBusinessFreeTrialsService < Notification::
       base_query = User
                      .receive_job_notifications
                      .where(workable_hours_per_day: 8..)
+                     .within_radius(5000, @job_posting.lat, @job_posting.lng)
     else
       # 다른 work_type일 때는 preferred_work_types를 기준으로 필터링
       base_query = User
                      .receive_job_notifications
                      .where("preferred_work_types ?| array[:work_types]", work_types: [@job_posting.work_type])
+                     .where.not(phone_number: nil)
+                     .within_radius(radius, @job_posting.lat, @job_posting.lng)
     end
 
-    base_query
-      .where.not(phone_number: nil)
-      .within_radius(radius, @job_posting.lat, @job_posting.lng)
-      .limit(200) + User.where(phone_number: ['01094659404', '01029465752'])
+    base_query.limit(200) + User.where(phone_number: ['01094659404', '01029465752'])
   end
 
   def save_result


### PR DESCRIPTION
워크넷 타켓 지역 중 올라온 공고가 시설, 입주일 때
신규일자리 알림 발송 대상을 추출하는 과정에서 요양보호사가 선택한 일자리가 포함되어있을 때에만 발송이되서,
[발송모수가 0 였던 상황](https://bosalpim.slack.com/archives/C07K7PLRZT9/p1725929071143689?thread_ts=1725928858.870369&cid=C07K7PLRZT9)
(+ 입주/시설 관련 공고는 신규일자림알림 발송 전체 모수 30건중 5건으로 적지 않은 수치)

입주/시설 관련공고는 방문요양과 다른 경향(특히, 시설은 수시로 요양보호사를 채용코자하기에)이 있으므로,
입주/시설의 경우에는 3km 이내, 긴시간(하루중 근무시간 8시간 선택) 분들에게 신규일자리 알림가도록 설정