### PR TITLE
FIX: 공고 자동 종료 메세지 예약발송 10시로 보내도록 수정

### DIFF
--- a/app/services/notification/factory/notify_close_free_job_posting.rb
+++ b/app/services/notification/factory/notify_close_free_job_posting.rb
@@ -54,6 +54,7 @@ class Notification::Factory::NotifyCloseFreeJobPosting < Notification::Factory::
       target_public_id: client.public_id
     }
 
-    @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, client.phone_number, params, client.public_id, 'AI'))
+    reserved_dt = DateTime.now.strftime("%Y%m%d") + "100000"
+    @bizm_post_pay_list.push(BizmPostPayMessage.new(@message_template_id, client.phone_number, params, client.public_id, 'AI', reserved_dt))
   end
 end


### PR DESCRIPTION
수정 과정에서 예약발송 코드가 제거되어, 새벽 4시에 발송되고 있는 상황.
10시에 전송이 되도록 기존 코드 원복