### PR TITLE
params 변환 안되어서, 플러스톡 보내지지 않았던 오류 수정

### DIFF
--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -186,13 +186,13 @@ class NotificationController < ApplicationController
           :notify,
           {
             message_template_id: params[:template],
-            params: params
+            params: params.to_h
           }) if Jets.env.development?
         NotificationServiceJob.perform_later(
           :notify,
           {
             message_template_id: params[:template],
-            params: params
+            params: params.to_h
           }) unless Jets.env.development?
       end
 

--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -186,13 +186,13 @@ class NotificationController < ApplicationController
           :notify,
           {
             message_template_id: params[:template],
-            params: params.to_h
+            params: params.to_unsafe_h
           }) if Jets.env.development?
         NotificationServiceJob.perform_later(
           :notify,
           {
             message_template_id: params[:template],
-            params: params.to_h
+            params: params.to_unsafe_h
           }) unless Jets.env.development?
       end
 


### PR DESCRIPTION
params를 hash로 변환하여 정상적으로 발송될 수 있도록 수정했습니다.