### PR TITLE
Update fcm_service.rb

### DIFF
--- a/app/services/fcm/fcm_service.rb
+++ b/app/services/fcm/fcm_service.rb
@@ -60,6 +60,14 @@ class Fcm::FcmService
         },
         data: {
           deeplink: message[:link]
+        },
+        android: {
+          priority: 'high',
+          notification: {
+            channelId: 'high_importance_channel',
+            title: message[:title],
+            body: message[:body],
+          }
         }
       }
     }


### PR DESCRIPTION
앱이 백그라운드인 상태에서 알림이 알림센터뿐만 아니라, 기기 화면에도 활성화되도록 합니다.